### PR TITLE
Expose and enable microscope type option for segmentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,38 @@
 slurm*
+
+# Windows default autosave extension
+*.asv
+
+# OSX / *nix default autosave extension
+*.m~
+
+# Compiled MEX binaries (all platforms)
+# *.mex*
+
+# Packaged app and toolbox files
+*.mlappinstall
+*.mltbx
+
+# Generated helpsearch folders
+helpsearch*/
+
+# Simulink code generation folders
+slprj/
+sccprj/
+
+# Matlab code generation folders
+codegen/
+
+# Simulink autosave extension
+*.autosave
+
+# Simulink cache files
+*.slxc
+
+# Octave session info
+octave-workspace
+
+# Visual Studio Code
+.vscode/*
+!.vscode/extensions.json
+!.vscode/tasks.json

--- a/confocalanalyze.sh
+++ b/confocalanalyze.sh
@@ -48,7 +48,7 @@ exitstatus=$?
 if [ $exitstatus -eq 0 -o $exitstatus -eq 123 ]
 then
 	mkdir --mode=775 -p $datadir
-	cp ${analyzedir}/Out/in/in_segmentation.png "${datadir}/${outnameprefix}segmentation.png"
+	cp "${analyzedir}/Out/in/in_segmentation.png.gz" "${datadir}/${outnameprefix}segmentation.png.gz"
 	if [ -f ${analyzedir}/Out/in/in_features.csv ]
 	then
 		mv ${analyzedir}/Out/in/in_features.csv "${analyzedir}/Out/in/${outnameprefix}features.csv"

--- a/confocalanalyze.sh
+++ b/confocalanalyze.sh
@@ -5,9 +5,9 @@ dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 pid=$$
 basedir=/tmp/IFanalyze
 
-if [ $# -ne 6 ]
+if [ $# -ne 8 ]
 then
-	echo "Missing or extra arguments, 6 needed"
+	echo "Missing or extra arguments, 8 needed"
 	exit 120
 fi
 
@@ -17,6 +17,8 @@ special_color=$3
 datadir=$4
 override=$5
 runcellcycle=$6
+pattern=$7
+mstype=$8
 
 outnameprefix=`basename ${filename}`
 analyzedir=${basedir}/${pid}
@@ -38,7 +40,7 @@ then
 fi
 
 # Call the script
-/usr/local/bin/matlab -nodisplay -nodesktop -nosplash -singleCompThread -r "cd $dir; featextraction('$dir', '$analyzedir', $resolution, '$special_color', $override, $runcellcycle);"
+/usr/local/bin/matlab -nodisplay -nodesktop -nosplash -singleCompThread -r "cd $dir; featextraction('$dir', '$analyzedir', $resolution, '$special_color', $override, $runcellcycle, '$pattern', '$mstype');"
 
 
 exitstatus=$?

--- a/examples.txt
+++ b/examples.txt
@@ -1,0 +1,6 @@
+
+# Run analysis. ko1_H1_3_ is the prefix of the images to run the analysis on. Need the trailing _ to not copy too images for other samples
+./confocalanalyze.sh /image/directory/ko1_H1_3_ 0.160 yellow /output/directory 0 0
+
+# Works with both features.csv and features.csv.gz
+/usr/local/bin/matlab -nodisplay -nodesktop -nosplash -singleCompThread -r "cd ./feature_extraction/siRNA_scripts; create_oldfeats('ko1_H1_3_features.csv.gz', '/tmp/outtempdirectory');"

--- a/examples.txt
+++ b/examples.txt
@@ -1,6 +1,6 @@
 
 # Run analysis. ko1_H1_3_ is the prefix of the images to run the analysis on. Need the trailing _ to not copy too images for other samples
-./confocalanalyze.sh /image/directory/ko1_H1_3_ 0.160 yellow /output/directory 0 0
+./confocalanalyze.sh /image/directory/ko1_H1_3_ 0.160 yellow /output/directory "[]" 0 "" widefield
 
 # Works with both features.csv and features.csv.gz
 /usr/local/bin/matlab -nodisplay -nodesktop -nosplash -singleCompThread -r "cd ./feature_extraction/siRNA_scripts; create_oldfeats('ko1_H1_3_features.csv.gz', '/tmp/outtempdirectory');"

--- a/featextraction.m
+++ b/featextraction.m
@@ -1,8 +1,9 @@
-function featextraction(funcdir, analyzedir, resolution, special_color, override, runcellcycle)
-addpath(genpath(strcat(funcdir, '/feature_extraction')));
+function featextraction(funcdir, analyzedir, resolution, special_color, override, runcellcycle, pattern, mstype)
+addpath(genpath(strcat(funcdir, '/features')));
+addpath(genpath(strcat(funcdir, '/helperfuncs')));
 addpath(genpath(strcat(funcdir,'/cellcycle')));
 try
-	[arr exit_status] = process_img(strcat(analyzedir,'/In'),strcat(analyzedir,'/Out'), resolution, special_color, override);
+	[arr exit_status] = process_img(strcat(analyzedir,'/In'),strcat(analyzedir,'/Out'), resolution, special_color, override, pattern, mstype);
 catch e
     fprintf(2, 'Threw id: %s\n', e.identifier);
     fprintf(2, 'Threw message: %s\n', e.message);

--- a/featextraction.m
+++ b/featextraction.m
@@ -1,0 +1,22 @@
+function featextraction(funcdir, analyzedir, resolution, special_color, override, runcellcycle)
+addpath(genpath(strcat(funcdir, '/feature_extraction')));
+addpath(genpath(strcat(funcdir,'/cellcycle')));
+try
+	[arr exit_status] = process_img(strcat(analyzedir,'/In'),strcat(analyzedir,'/Out'), resolution, special_color, override);
+catch e
+    fprintf(2, 'Threw id: %s\n', e.identifier);
+    fprintf(2, 'Threw message: %s\n', e.message);
+    getReport(e)
+	exit(122);
+end
+
+if exit_status(1)==0
+	if runcellcycle==1
+		try
+			predict_CCpos_fov(recursive_getPaths(strcat(analyzedir,'/Out/in'), '_features.csv'));
+		catch
+			exit(123);
+		end
+	end
+end
+exit(exit_status(1));

--- a/features/hpa_lib/HPA_lib/SLICfeatures/matlab/ml_rcthreshold.m
+++ b/features/hpa_lib/HPA_lib/SLICfeatures/matlab/ml_rcthreshold.m
@@ -1,0 +1,110 @@
+function threshold = ml_rcthreshold(img)
+    % ML_RCTHRESHOLD - Find a threshold for IMAGE
+    % ML_RCTHRESHOLD(IMAGE) - input is output from nihscale(image)
+    % output is threshold value using same algorithm as nih image
+    % Ridler and Calvard (IEEE tans. on Systems, man, cybernetics
+    % SMC-8 no 8 aug 1978)
+    % Trussel (same journal) SMC-9 no 5 may 1979
+    %
+    % Basically, the algorithm moves the proposed threshold from the
+    % minimum non-zero bin of the histogram to the maximum non-zero bin.
+    % While doing so, it calculates the 'center of mass' separately
+    % for that part of the histogram below the proposed threshold and
+    % that part above.  While the proposed threshold is less than
+    % the mean of these two centers of mass, the algorithm continues.
+    % When this condition no longer holds, the proposed threshold is
+    % rounded to give a final result.
+    %
+    % If <= one intensity value is nonzero output threshold will be 1/2
+    % and error message will be printed to screen
+    %
+    % 20 Aug 98 - M.V. Boland.  Modified from version written by W. Dirks.
+    %
+    % Sometime in Year 2000, MV and RFM noticed that the algorithm
+    % had not been implemented properly. Corrected by MV and RFM.
+
+    % Copyright (C) 2006  Murphy Lab
+    % Carnegie Mellon University
+    %
+    % This program is free software; you can redistribute it and/or modify
+    % it under the terms of the GNU General Public License as published
+    % by the Free Software Foundation; either version 2 of the License,
+    % or (at your option) any later version.
+    %
+    % This program is distributed in the hope that it will be useful, but
+    % WITHOUT ANY WARRANTY; without even the implied warranty of
+    % MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    % General Public License for more details.
+    %
+    % You should have received a copy of the GNU General Public License
+    % along with this program; if not, write to the Free Software
+    % Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+    % 02110-1301, USA.
+    %
+    % For additional information visit http://murphylab.web.cmu.edu or
+    % send email to murphy@cmu.edu
+
+    %Modified by T. Zhao to fix bugs
+
+    % $Id: ml_rcthreshold.m,v 1.3 2006/06/27 13:33:47 tingz Exp $
+
+    %
+    % Generate a 256 bin histogram
+    %
+    % only take uint8 image
+
+    if strcmp(class(img),'uint8')~=1
+        error('Wrong data type! The image should be uint8.');
+    end
+
+    imgsize=size(img);
+
+    if length(imgsize)>2
+        img=reshape(img,imgsize(1),prod(imgsize(2:end)));
+    end
+
+    histo = imhist(img(:),256);
+
+    hsum = sum(histo);
+
+
+    histo(1) = [];
+    histo(255) = 0;
+
+    whitepos=find(histo>0);
+    MinIndex=1;
+    MaxIndex=1;
+    if ~isempty(whitepos)
+        MinIndex=whitepos(1);
+        MaxIndex=whitepos(end);
+    end
+
+    if (MinIndex >= MaxIndex)
+        threshold = MinIndex;
+        warning('There is <= 1 nonzero pixel intensity');
+        return;
+    end;
+
+    MovingIndex = MinIndex+1;
+
+    Prev = MinIndex;
+    while (Prev ~= MovingIndex)
+        if (MovingIndex >= MaxIndex)
+            break;
+        end;
+
+        sum1 = sum([MinIndex:MovingIndex-1]' .* ...
+            histo(MinIndex:MovingIndex-1)) ;
+        sum2 = sum(histo(MinIndex:MovingIndex-1)) ;
+        sum3 = sum([MovingIndex:MaxIndex]' .* ...
+            histo(MovingIndex:MaxIndex)) ;
+        sum4 = sum(histo(MovingIndex:MaxIndex)) ;
+
+        Prev = MovingIndex;
+        loweravg=sum1/sum2;
+        higheravg=sum3/sum4;
+
+        MovingIndex = ceil((loweravg + higheravg)/2) ;
+    end
+
+    threshold = MovingIndex;

--- a/features/hpa_lib/HPA_lib/segmentation/preprocessImages.m
+++ b/features/hpa_lib/HPA_lib/segmentation/preprocessImages.m
@@ -1,7 +1,7 @@
 function [nucfiles, skipimage] = preprocessImages(imagedir,namingconvention,outputdir)
 %This function checks that each channel has been scanned properly all the
 %way. If one channel has not, it throws a warning and then trims all the
-%channels to the smallest scanned area. 
+%channels to the smallest scanned area.
 %
 %INPUTS:
 %imagedir - string pointing to the directory where images are
@@ -10,7 +10,7 @@ function [nucfiles, skipimage] = preprocessImages(imagedir,namingconvention,outp
 %   protein_channel - suffix for protein channel e.g. '_green.tif'
 %   tubulin_channel - suffix for tubulin channel e.g. '_red.tif'
 %   er_channel - suffix for er channel e.g. '_yellow.tif'
-%outputdir - string pointing to where results should be saved. 
+%outputdir - string pointing to where results should be saved.
 %OUTPUTS:
 %
 %Written by: Devin P Sullivan 07,08,2015
@@ -21,26 +21,26 @@ function [nucfiles, skipimage] = preprocessImages(imagedir,namingconvention,outp
 %take the hit here and copy all the files to the new directory. This is the
 %cleanest way I can think to do this right now. I know this is a
 %significant performance hit for a rather rare issue, but otherwise we need
-%to replace all our original images - ASK EMMA about this. 
+%to replace all our original images - ASK EMMA about this.
 newimgdir = [outputdir,filesep,'failedimages'];
 
 if ~isdir(newimgdir)
     mkdir(newimgdir)
 end
 
-%first get all the paths 
+%first get all the paths
 % nucpath = [imagedir,filesep,'*',namingconvention.pattern,'*',namingconvention.nuclear_channel,'*'];
 nucpath = [imagedir,'*',namingconvention.pattern,'*',namingconvention.nuclear_channel,'*'];
 nucfiles = ml_ls(nucpath);
-% protpath = [imagedir,filesep,'*',namingconvention.pattern,'*',namingconvention.protein_channel,'*']; 
-protpath = [imagedir,'*',namingconvention.pattern,'*',namingconvention.protein_channel,'*']; 
+% protpath = [imagedir,filesep,'*',namingconvention.pattern,'*',namingconvention.protein_channel,'*'];
+protpath = [imagedir,'*',namingconvention.pattern,'*',namingconvention.protein_channel,'*'];
 protfiles = ml_ls(protpath);
-% mtpath = [imagedir,filesep,'*',namingconvention.pattern,'*',namingconvention.tubulin_channel,'*']; 
-mtpath = [imagedir,'*',namingconvention.pattern,'*',namingconvention.tubulin_channel,'*']; 
+% mtpath = [imagedir,filesep,'*',namingconvention.pattern,'*',namingconvention.tubulin_channel,'*'];
+mtpath = [imagedir,'*',namingconvention.pattern,'*',namingconvention.tubulin_channel,'*'];
 mtfiles = ml_ls(mtpath);
-% erpath = [imagedir,filesep,'*',namingconvention.pattern,'*',namingconvention.er_channel,'*'] 
-erpath = [imagedir,'*',namingconvention.pattern,'*',namingconvention.er_channel,'*'] 
-erfiles = ml_ls(erpath)
+% erpath = [imagedir,filesep,'*',namingconvention.pattern,'*',namingconvention.er_channel,'*']
+erpath = [imagedir,'*',namingconvention.pattern,'*',namingconvention.er_channel,'*'];
+erfiles = ml_ls(erpath);
 
 if any(strcmpi(namingconvention.blank_channels,'nuc'))
     error('The nuclear channel cannot be blank as it is needed for segmentation!')
@@ -74,7 +74,7 @@ for i = 1:length(nucfiles)
     protim = removergb(protim);
     mtim = removergb(mtim);
     erim = removergb(erim);
-   
+
    %Check if any are totally empty
    %Nuc
 %    if sum(nucim(:))==0
@@ -100,14 +100,14 @@ for i = 1:length(nucfiles)
        skipimage(i,4) = 1;
 %        namingconvention.blank_channels = [namingconvention.blank_channels,{'er'}];
    end
-   
+
    %Next check if any of the channels have partial scans
-   %Nuc 
+   %Nuc
    [xrangenuc,yrangenuc,partialnuc] = checkPartialScan(nucim);
    if partialnuc && ~skipimage(i,1)
        skipimage(i,1) = 2;
    end
-   %Prot 
+   %Prot
    [xrangeprot,yrangeprot,partialprot] = checkPartialScan(protim);
    if partialprot && ~skipimage(i,2)
        skipimage(i,2) = 2;
@@ -122,16 +122,16 @@ for i = 1:length(nucfiles)
    if partialer && ~skipimage(i,4)
        skipimage(i,4) = 2;
    end
-   
+
    %DPS 10/08/2015 - After talking to Emma, we decided to just discard
-   %partially scanned images rather than trim them. 
-%    %Find the smallest dimensions where we have fluorescence 
+   %partially scanned images rather than trim them.
+%    %Find the smallest dimensions where we have fluorescence
 %    xstart = max([min(xrangenuc),min(xrangeprot),min(xrangemt),min(xrangeer)]);
 %    xend = min([max(xrangenuc),max(xrangeprot),max(xrangemt),max(xrangeer)]);
 %    ystart = max([min(yrangenuc),min(yrangeprot),min(yrangemt),min(yrangeer)]);
 %    yend = min([max(yrangenuc),max(yrangeprot),max(yrangemt),max(yrangeer)]);
-% 
-% 
+%
+%
 %    %If our start or end is not the full image, make new images and save
 %    %them somewhere
 %    if (xstart || ystart)>1 || xend<size(nucim,1) || yend<size(nucim,2)
@@ -139,7 +139,7 @@ for i = 1:length(nucfiles)
 %        newprotim = nucim(ystart:yend,xstart:xend);
 %        newmtim = nucim(ystart:yend,xstart:xend);
 %        newerim = nucim(ystart:yend,xstart:xend);
-%        
+%
 %        %Nuc
 %        [oldpath,nucname,ext] = fileparts(nucfiles{i});
 %        imwrite(newnucim,[newimgdir,filesep,nucname,ext])
@@ -152,10 +152,10 @@ for i = 1:length(nucfiles)
 %        %ER
 %        [oldpath,ername,ext] = fileparts(erfiles{i});
 %        imwrite(newerim,[newimgdir,filesep,ername,ext])
-%        
+%
 %    end
-   
-   
+
+
 end
 
 %DPS 10/08/15 - Since we are no longer trimming images, this is
@@ -175,7 +175,7 @@ end
 end
 
 function myimg = readmyimg(imgpath,channelname,namingconvention,imgsize)
-  
+
     %[~,filepath,ext] = fileparts(imgpath);
     if nargin<2 || isempty(channelname)
        channelname = 'nothing';
@@ -199,7 +199,7 @@ function myimg = readmyimg(imgpath,channelname,namingconvention,imgsize)
 	%else
 	  %myimg = imread(imgpath);
 	%end
-	
+
     end
 
 end


### PR DESCRIPTION
- Add pattern and microscope type options in shell script and matlab entry point. We don't care about the pattern option, but it needs to be in place to logically expose the microscope type option in the positional parameters of the shell and matlab entry points. The microscope option takes either a `confocal` (the default) or `widefield` string argument.
- Add missing ml_rcthreshold matlab function. This function is used when selecting `widefield` as segmentation flow, ie for widefield images.
- Fix png gzip file copy in shell script.
- Update example with correct call signature.